### PR TITLE
Fix semicolons in trailing positions in expression-like macros

### DIFF
--- a/dpll/src/recursive/backjump.rs
+++ b/dpll/src/recursive/backjump.rs
@@ -6,8 +6,8 @@ prelude!();
 pub type Γ<Lit> = Map<Lit, Set<Lit>>;
 
 macro_rules! raise {
-	{ sat $γ:expr } => { return Err(Outcome::Sat($γ)); };
-	{ unsat $deps:expr } => { return Err(Outcome::Unsat($deps)); };
+	{ sat $γ:expr } => { return Err(Outcome::Sat($γ)) };
+	{ unsat $deps:expr } => { return Err(Outcome::Unsat($deps)) };
 }
 
 pub type Out<Lit> = Outcome<Lit, Set<Lit>>;

--- a/dpll/src/recursive/cdcl.rs
+++ b/dpll/src/recursive/cdcl.rs
@@ -6,8 +6,8 @@ prelude!();
 pub type Γ<Lit> = Map<Lit, Set<Lit>>;
 
 macro_rules! raise {
-	{ sat $γ:expr } => { return Err(Outcome::Sat($γ)); };
-	{ unsat $deps:expr } => { return Err(Outcome::Unsat($deps)); };
+	{ sat $γ:expr } => { return Err(Outcome::Sat($γ)) };
+	{ unsat $deps:expr } => { return Err(Outcome::Unsat($deps)) };
 }
 
 pub type LClauses<Lit> = Set<LClause<Lit>>;

--- a/dpll/src/recursive/plain.rs
+++ b/dpll/src/recursive/plain.rs
@@ -8,8 +8,8 @@ pub type Γ<Lit> = Set<Lit>;
 pub type Out<Lit> = crate::Outcome<Lit, ()>;
 
 macro_rules! raise {
-	{ sat $γ:expr } => { return Err(Out::Sat($γ)); };
-	{ unsat } => { return Err(Out::Unsat(())); };
+	{ sat $γ:expr } => { return Err(Out::Sat($γ)) };
+	{ unsat } => { return Err(Out::Unsat(())) };
 }
 
 pub type Res<T, Lit> = Result<T, Out<Lit>>;

--- a/front/src/parse.rs
+++ b/front/src/parse.rs
@@ -84,7 +84,7 @@ impl<R: Read> Parser<R> {
         }
         macro_rules! bail {
             {} => {
-                return Err(err!().into());
+                return Err(err!().into())
             };
         }
 


### PR DESCRIPTION
Had became a rust warning
cf https://github.com/rust-lang/rust/issues/79813
